### PR TITLE
bcrypt with no dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "asyncawait": "^1.0.6",
     "aws-sdk": "^2.266.1",
     "aws4": "^1.8.0",
-    "bcrypt": "^2.0.1",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "dotenv": "^6.0.0",

--- a/src/models/import.js
+++ b/src/models/import.js
@@ -1,6 +1,5 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
-const bcrypt = require("bcrypt");
 
 const ImportSchema = new Schema({
   user: {

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
-const bcrypt = require("bcrypt");
+const bcrypt = require("bcryptjs");
 
 const UserSchema = new Schema({
   email: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,13 +573,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bcrypt@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-2.0.1.tgz#229c5afe09379789f918efe86e5e5b682e509f85"
-  integrity sha512-DwB7WgJPdskbR+9Y3OTJtwRq09Lmm7Na6b+4ewvXjkD0nfNRi1OozxljHm5ETlDCBq9DTy04lQz+rj+T2ztIJg==
-  dependencies:
-    nan "2.10.0"
-    node-pre-gyp "0.9.1"
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
 
 binary-extensions@^1.0.0:
   version "1.12.0"
@@ -3751,11 +3748,6 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
-  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
-
 nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
@@ -3783,7 +3775,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.0, needle@^2.2.1:
+needle@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
   integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
@@ -3821,22 +3813,6 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz#f11c07516dd92f87199dbc7e1838eab7cd56c9e0"
-  integrity sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.0"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -4405,7 +4381,7 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.1.7, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==


### PR DESCRIPTION
Crash avec la dernière version de bcrypt sur AWS:

```
    Application update failed at 2018-11-20T09:03:31Z with exit status 1 and error: Hook /opt/elasticbeanstalk/hooks/appdeploy/pre/50npm.sh failed.

    + /opt/elasticbeanstalk/containerfiles/ebnode.py --action npm-install

    > fibers@2.0.2 install /tmp/deployment/application/node_modules/fibers
    > node build.js || nodejs build.js

    `linux-x64-57` exists; testing
    Binary is fine; exiting

    > bcrypt@2.0.1 install /tmp/deployment/application/node_modules/bcrypt
    > node-pre-gyp install --fallback-to-build

    sh: node-pre-gyp: command not found
    npm WARN http-aws-es@6.0.0 requires a peer of elasticsearch@^15.0.0 but none is installed. You must install peer dependencies yourself.

    npm ERR! file sh
    npm ERR! code ELIFECYCLE
    npm ERR! errno ENOENT
    npm ERR! syscall spawn
    npm ERR! bcrypt@2.0.1 install: `node-pre-gyp install --fallback-to-build`
    npm ERR! spawn ENOENT
    npm ERR!
    npm ERR! Failed at the bcrypt@2.0.1 install script.
    npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

    npm ERR! A complete log of this run can be found in:
    npm ERR! /tmp/.npm/_logs/2018-11-20T09_03_31_486Z-debug.log
    Running npm install: /opt/elasticbeanstalk/node-install/node-v8.11.3-linux-x64/bin/npm
    Setting npm config jobs to 1
    npm config jobs set to 1
    Running npm with --production flag
    Failed to run npm install. Snapshot logs for more details.
    UTC 2018/11/20 09:03:31 cannot find application npm debug log at /tmp/deployment/application/npm-debug.log

    Traceback (most recent call last):
    File "/opt/elasticbeanstalk/containerfiles/ebnode.py", line 695, in <module>
    main()
    File "/opt/elasticbeanstalk/containerfiles/ebnode.py", line 677, in main
    node_version_manager.run_npm_install(options.app_path)
    File "/opt/elasticbeanstalk/containerfiles/ebnode.py", line 136, in run_npm_install
    self.npm_install(bin_path, self.config_manager.get_container_config('app_staging_dir'))
    File "/opt/elasticbeanstalk/containerfiles/ebnode.py", line 180, in npm_install
    raise e
    subprocess.CalledProcessError: Command '['/opt/elasticbeanstalk/node-install/node-v8.11.3-linux-x64/bin/npm', '--production', 'install']' returned non-zero exit status 1.
    Incorrect application version "app-393c-181120_090250" (deployment 124). Expected version "app-f1d4-181119_104515" (deployment 121).
```

C'est à cause de bcrypt. Source (entre autres): https://github.com/kelektiv/node.bcrypt.js/issues/650

En fait bcrypt repose sur une lib c++ (donc c'est galère). J'ai remplacé par https://www.npmjs.com/package/bcryptjs qui existe juste pour ça !!