### PR TITLE
prio sur COORDONNEE

### DIFF
--- a/src/controllers/merimee.js
+++ b/src/controllers/merimee.js
@@ -20,7 +20,7 @@ function transformBeforeUpdate(notice) {
 
   notice.CONTIENT_IMAGE =
     notice.MEMOIRE && notice.MEMOIRE.length ? "oui" : "non";
-  if (notice.COOR && notice.ZONE) {
+  if (notice.COOR && notice.ZONE && !notice.POP_COORDONNEES) {
     notice.POP_COORDONNEES = lambertToWGS84(notice.COOR, notice.ZONE);
   }
   notice.POP_CONTIENT_GEOLOCALISATION =
@@ -31,7 +31,7 @@ function transformBeforeCreate(notice) {
   notice.DMAJ = notice.DMIS = formattedNow();
   notice.CONTIENT_IMAGE =
     notice.MEMOIRE && notice.MEMOIRE.length ? "oui" : "non";
-  if (notice.COOR && notice.ZONE) {
+  if (notice.COOR && notice.ZONE && !notice.POP_COORDONNEES) {
     notice.POP_COORDONNEES = lambertToWGS84(notice.COOR, notice.ZONE);
   }
   notice.POP_CONTIENT_GEOLOCALISATION =


### PR DESCRIPTION
Pourquoi je ne l'avais pas fait dès le début : 
On gros si tu mets a jour lambert dans l'édition d'une notice qui a déja été converti en WGS84, avec cette correction la transformation ne sera pas refaite car POP_COORDONNEE sera déja généré.

Mais ca arrivera pas au début.